### PR TITLE
Fixes the use of the END_DATE parameter for a collection

### DIFF
--- a/main.py
+++ b/main.py
@@ -371,7 +371,7 @@ class MainPage(auth.AuthenticatedHandler, DataStats, DataSource, Reports):
             start_dt = datetime.datetime(2014, 9, 1)
         start_str = start_dt.strftime('%Y-%m-%d')
         the_end = self.get_collection_metadata('END_DATE', '2015-01-01')
-        if end_str > '2015-01-01':
+        if end_str > the_end:
             the_end = end_str
 
         try:


### PR DESCRIPTION
This is a small change to correct the logic in main.py, so the END_DATE parameter for a collection is actually used in determining the END_DATE. If END_DATE is specified, it is used as the cutoff for computing activity by day (see [L598](https://github.com/codyaustun/xanalytics/blob/end_date/stats.py#L598) in stats.py). If END_DATE isn't specified and the course has launched, the cutoff is the maximum between '2015-01-01'  and 114 days after the course launch. If the course hasn't launched and END_DATE isn't specified, then the cutoff is the maximum between '2015-01-01' and 58 days after the course launch (see [L361-L374](https://github.com/codyaustun/xanalytics/blob/end_date/main.py#L361)  in main.py].
