### PR TITLE
Add support for regex search in table search

### DIFF
--- a/html/custom_report_default.js
+++ b/html/custom_report_default.js
@@ -30,6 +30,7 @@ var make_report = function() {
       "columns": tablecolumns,
       "pageLength": 10,
       searching: true,
+      search:{"regex": true},
       ordering: optarg.ordering==null ? true : optarg.ordering,
       paging: optarg.paging==null ? true : optarg.paging,
       order: optarg.order,


### PR DESCRIPTION
Adding support for regex search in the table search has no impact on regular searching and does not break any previous behavior, but allows for regex expressions while searching tables.
